### PR TITLE
Improve exception handling

### DIFF
--- a/app/common.py
+++ b/app/common.py
@@ -256,3 +256,14 @@ def sign_data(data):
     message_hash = defunct_hash_message(text=str(message))
     signature = w3_auto.eth.account.signHash(message_hash, private_key=node_key_store.private_key)
     return signature['signature'].hex()
+
+
+def pause_job(scheduler, job_id, minutes=5):
+    try:
+        scheduler.get_job(job_id=job_id).pause()
+        time.sleep(60 * minutes)
+        scheduler.get_job(job_id=job_id).resume()
+    except Exception:
+        logger.exception('Pause job')
+        return False
+    return True

--- a/app/common.py
+++ b/app/common.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import time
 from enum import Enum
 
 import requests
@@ -134,6 +135,10 @@ def function_transact(w3, contract_function, max_retries=3):
         except web3.utils.threads.Timeout as e:
             logger.info('Replacing transaction with increased gas price. Retry %d/%d: %s',
                         attempt + 1, max_retries, e)
+        except (requests.exceptions.ReadTimeout, requests.exceptions.ConnectionError) as e:
+            logger.info('Transaction %s exception. Sleeping 1 minute then retry it',
+                        e.__class__.__name__)
+            time.sleep(60 * 1)
         except Exception:
             logger.exception('New transaction with new nonce. Retry: %d/%d', attempt + 1,
                              max_retries)

--- a/app/database/database.py
+++ b/app/database/database.py
@@ -104,6 +104,10 @@ class VerityEvent(BaseEvent):
         """ Generate a job ID for consensus not reached job """
         return '%s_process_consensus_not_reached' % event_id
 
+    def post_application_end_time_job_id(event_id):
+        """ Generate a job ID for post applicationend time job """
+        return '%s_post_application_end_time' % event_id
+
     def votes(self, min_votes=None, max_votes=None, filter_by_vote=None, check_uniqueness=True):
         """ Returns votes by users based on filters specified """
         min_votes = min_votes or 2

--- a/app/database/database.py
+++ b/app/database/database.py
@@ -211,7 +211,8 @@ class VerityEventMetadata(BaseEvent):
     PREFIX = 'metadata'
 
     def __init__(self, event_id, is_consensus_reached, node_ips, node_websocket_ips,
-                 contract_block_number, previous_consensus_answers, processing_end_time):
+                 contract_block_number, previous_consensus_answers, processing_end_time,
+                 should_run_filters, filters_exception_reported):
         self.event_id = event_id
         self.is_consensus_reached = is_consensus_reached
         self.node_ips = node_ips
@@ -219,6 +220,8 @@ class VerityEventMetadata(BaseEvent):
         self.contract_block_number = contract_block_number
         self.previous_consensus_answers = previous_consensus_answers
         self.processing_end_time = processing_end_time
+        self.should_run_filters = should_run_filters
+        self.filters_exception_reported = filters_exception_reported
 
     def create(self):
         redis_db.set(self.key(self.event_id), self.to_json())
@@ -234,7 +237,9 @@ class VerityEventMetadata(BaseEvent):
                 node_websocket_ips=[],
                 contract_block_number=0,
                 previous_consensus_answers=None,
-                processing_end_time=None)
+                processing_end_time=None,
+                should_run_filters=True,
+                filters_exception_reported=False)
             event_metadata.create()
         return event_metadata
 

--- a/app/events/event_registry_filter.py
+++ b/app/events/event_registry_filter.py
@@ -163,7 +163,8 @@ def filter_event_registry(scheduler, w3, event_registry_address, verity_event_ab
         recover_filter(scheduler, w3, verity_event_abi, event_registry_address)
         return
     except (requests.exceptions.ReadTimeout, requests.exceptions.ConnectionError) as e:
-        logger.info('EventRegistry %s exception. Sleeping for 5 minutes then recover it', e.__class__.__name__)
+        logger.info('EventRegistry %s exception. Sleeping for 5 minutes then recover it',
+                    e.__class__.__name__)
         scheduler.get_job(job_id='event_registry_filter').pause()
         time.sleep(60 * 5)
         recover_filter(scheduler, w3, verity_event_abi, event_registry_address)

--- a/app/events/event_registry_filter.py
+++ b/app/events/event_registry_filter.py
@@ -150,6 +150,12 @@ def recover_filter(scheduler, w3, verity_event_abi, event_registry_address):
         logger.info('Unexpected exception during event registry recovery: %s', e)
 
 
+def pause_event_registry_filter(scheduler, minutes=5):
+    scheduler.get_job(job_id='event_registry_filter').pause()
+    time.sleep(60 * minutes)
+    scheduler.get_job(job_id='event_registry_filter').resume()
+
+
 def filter_event_registry(scheduler, w3, event_registry_address, verity_event_abi, formatters):
     ''' Runs in a cron job and checks for new verity events'''
     filter_id = database.Filters.get_list(event_registry_address)[0]['filter_id']
@@ -165,17 +171,13 @@ def filter_event_registry(scheduler, w3, event_registry_address, verity_event_ab
     except (requests.exceptions.ReadTimeout, requests.exceptions.ConnectionError) as e:
         logger.info('EventRegistry %s exception. Sleeping for 5 minutes then recover it',
                     e.__class__.__name__)
-        scheduler.get_job(job_id='event_registry_filter').pause()
-        time.sleep(60 * 5)
+        pause_event_registry_filter(scheduler)
         recover_filter(scheduler, w3, verity_event_abi, event_registry_address)
-        scheduler.get_job(job_id='event_registry_filter').resume()
         return
     except Exception:
         logger.exception(
-            'Event Registry unexpected exception. Sleeping for 10 minutes then recover it')
-        scheduler.get_job(job_id='event_registry_filter').pause()
-        time.sleep(60 * 10)
+            'Event Registry unexpected exception. Sleeping for 5 minutes then recover it')
+        pause_event_registry_filter(scheduler)
         recover_filter(scheduler, w3, verity_event_abi, event_registry_address)
-        scheduler.get_job(job_id='event_registry_filter').resume()
         return
     process_new_verity_events(scheduler, w3, verity_event_abi, entries)

--- a/app/events/event_registry_filter.py
+++ b/app/events/event_registry_filter.py
@@ -76,6 +76,7 @@ def schedule_consensus_not_reached_job(scheduler, event_id, event_end_time):
         consensus.process_consensus_not_reached,
         'date',
         run_date=job_datetime,
+        replace_existing=True,
         args=[event_id],
         id=job_id)
     logger.info('[%s] Scheduled process_consensus_not_reached_job at %s', event_id, job_datetime)
@@ -84,6 +85,7 @@ def schedule_consensus_not_reached_job(scheduler, event_id, event_end_time):
 def schedule_post_application_end_time_job(scheduler, w3, event_id, application_end_time):
     application_end_datetime = datetime.fromtimestamp(application_end_time, timezone.utc)
     job_datetime = application_end_datetime + timedelta(minutes=1)
+    job_id = database.VerityEvent.post_application_end_time_job_id(event_id)
     if datetime.now(timezone.utc) > job_datetime:
         logger.info('[%s] Skipping post_application_end_time_job', event_id)
         return
@@ -95,7 +97,9 @@ def schedule_post_application_end_time_job(scheduler, w3, event_id, application_
         verity_event_filters.post_application_end_time_job,
         'date',
         run_date=job_datetime,
-        args=[w3, event_id])
+        replace_existing=True,
+        args=[w3, event_id],
+        id=job_id)
     logger.info('[%s] Scheduled post_application_end_time_job at %s', event_id, job_datetime)
 
 

--- a/app/events/verity_event_filters.py
+++ b/app/events/verity_event_filters.py
@@ -260,9 +260,10 @@ def proccess_filters_for_event(scheduler, w3, formatters, event_id, filter_list,
             recover_filter(w3, event_id, filter_name, filter_func, filter_id=filter_id)
             continue
         except (requests.exceptions.ReadTimeout, requests.exceptions.ConnectionError) as e:
-            logger.info('[%s] %s with %s filter. Sleeping 5 minutes', event_id,
-                        e.__class__.__name__, filter_name)
-            pause_filter_event_job(scheduler)
+            sleep_minutes = 5
+            logger.info('[%s] %s with %s filter. Sleeping %d minutes', event_id,
+                        e.__class__.__name__, filter_name, sleep_minutes)
+            common.pause_job(scheduler, 'filter_events', minutes=sleep_minutes)
             recover_all_filters(w3, event_id, filter_list)
             return
         except Exception:
@@ -290,12 +291,6 @@ def schedule_post_unexpected_exception_job(scheduler, w3, event_id, event_metada
         'date',
         run_date=job_datetime,
         args=[w3, event_id, filter_list])
-
-
-def pause_filter_event_job(scheduler, minutes=5):
-    scheduler.get_job(job_id='filter_events').pause()
-    time.sleep(60 * minutes)
-    scheduler.get_job(job_id='filter_events').resume()
 
 
 def post_unexpected_exception_job(w3, event_id, filter_list):

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -66,6 +66,7 @@ def init(w3):
         'interval',
         seconds=10,
         args=[scheduler, w3, verity_event_formatters],
+        id='filter_events'
     )
 
     scheduler.add_job(


### PR DESCRIPTION
Improve logic for exception handling. Node recovers state when Geth node goes down. I am going to fix transactions in the next PR.

Changes:
 - surround get_nonce in a try except block and retry.
 - add should_run_filters flag to metadata to enable/disable filters per event.
 - add filters_exception_reported flag to metadata so that unexpected exception is reported only once.
 - Improve exception handling in event registry filter.
 - surround get_ip in a try except block.
 - Improve exception handling for event filters.


