### PR TITLE
Init all filters

### DIFF
--- a/app/database/database.py
+++ b/app/database/database.py
@@ -344,7 +344,7 @@ class Rewards(BaseEvent):
     @classmethod
     def transform_dict_to_lists(cls, rewards):
         if rewards is None:
-            logger.error('Transform_dict_to_lists called with None')
+            logger.info('transform_dict_to_lists called with None')
             return [], [], []
         user_ids = list(rewards.keys())
         eth_rewards, token_rewards = [], []

--- a/app/events/event_registry_filter.py
+++ b/app/events/event_registry_filter.py
@@ -115,7 +115,7 @@ def schedule_post_application_end_time_job(scheduler, w3, event_id, application_
         'date',
         run_date=job_datetime,
         replace_existing=True,
-        args=[w3, event_id],
+        args=[scheduler, w3, event_id],
         id=job_id)
     logger.info('[%s] Scheduled post_application_end_time_job at %s', event_id, job_datetime)
 
@@ -144,7 +144,7 @@ def init_event(scheduler, w3, contract_abi, event_id, contract_block_number):
     event_metadata.previous_consensus_answers = common.consensus_answers_from_contract(
         event_instance)
     event_metadata.update()
-    verity_event_filters.init_event_filters(w3, contract_abi, event.event_id)
+    verity_event_filters.init_event_filters(scheduler, w3, contract_abi, event.event_id)
     schedule_post_application_end_time_job(scheduler, w3, event_id, event.application_end_time)
     schedule_consensus_not_reached_job(scheduler, event_id, event.event_end_time)
     logger.info('[%s] Event initialized', event_id)

--- a/app/events/verity_event_filters.py
+++ b/app/events/verity_event_filters.py
@@ -55,6 +55,10 @@ def process_validation_start(scheduler, w3, event_id, entries):
     if event is None:
         logger.info('[%s] Event does not exist', event_id)
         return
+    event_instance = database.VerityEvent.instance(w3, event_id)
+    if event_instance.functions.validationState().call() != 1:
+        logger.info('[%s] Event is not in validating state', event_id)
+        return
 
     validation_round = entry['args']['validationRound']
     event.rewards_validation_round = validation_round

--- a/app/queue_service/transactions.py
+++ b/app/queue_service/transactions.py
@@ -55,11 +55,13 @@ def _next_nonce(w3, account_address, event_id, max_retries=3):
 
 
 def _should_execute_transaction(w3, contract_function, event_id):
-    if contract_function.fn_name in {'approveRewards', 'rejectRewards'}:
+    function_name = contract_function.fn_name
+    if function_name in {'approveRewards', 'rejectRewards'}:
         # avoid sending last approve or reject transaction that always fails
         event_instance = database.VerityEvent.instance(w3, event_id)
         if event_instance.functions.validationState().call() != 1:
-            logger.info('[%s] Event is not in validating state. Skipping transaction', event_id)
+            logger.info('[%s] Event is not in validating state. Skipping %s', event_id,
+                        function_name)
             return False
     return True
 


### PR DESCRIPTION
If Geth node was not accessible when the master node finished setting rewards, other nodes didn't receive Validation Started event log.

Changes:
 - recover Validation Started event log,
 - check if the event is the right state that validation can be started,
 - pass scheduler instance to all methods that could call recover filter.

Further work:
 - Do the same for Dispute triggered and validation restart event logs.